### PR TITLE
Prefer direct solve over multiplication with explicit inverse

### DIFF
--- a/doe/jacobian.py
+++ b/doe/jacobian.py
@@ -94,14 +94,11 @@ class JacobianForLogdet:
         # first part of jacobian
         J1 = (
             -2
-            * X
-            @ sp.linalg.solve(
-                X.T @ X + self.delta * np.eye(self.n_model_terms),
-                np.eye(self.n_model_terms),
-                sym_pos=True,
-                overwrite_b=True,
-            )
+            * sp.linalg.solve(
+                X.T @ X + self.delta * np.eye(self.n_model_terms), X.T, assume_a="pos"
+            ).T
         )
+
         J1 = np.repeat(J1, self.n_vars, axis=0).reshape(
             self.n_experiments, self.n_vars, self.n_model_terms
         )


### PR DESCRIPTION
The evaluation of the Jacobian entails computing `-2 X (X^T X + \delta I)^{-1}`, which is currently done by forming the explict inverse of `X^T X + \delta I)^{-1}`, and multiplying that from the right to `X`.  But typically you'd get a more accurate result by directly solving the equivalent linear system.  This is the tiny proposal here.

The expected effect is that more accurate Jacobians lead to fewer iterations in the interior method that uses it.  I verified that the IPOPT iteration count drops by 15% (mean over ten different starting points) on an example + data set provided by folks at BASF, but you have more data than I to test it.
